### PR TITLE
Module loading breaks when processing multiple files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,18 @@ var es = require('event-stream');
 var merge = require('merge');
 
 module.exports = function(opts) {
-  var moduleCache = {};
+
+  if(opts.modules){
+    opts.modules = opts.modules.map(function(mod) {
+      return sweet.loadNodeModule(process.cwd(), mod);
+    });
+  }
+
+  if(opts.readtables){
+    opts.readtables.forEach(function(mod) {
+      sweet.setReadtable(mod);
+    });
+  }
 
   return es.through(function(file) {
     if(file.isNull()) {
@@ -22,21 +33,7 @@ module.exports = function(opts) {
     opts = merge({
       sourceMap: !!file.sourceMap,
       filename: file.path,
-      modules: [],
-      readtables: []
     }, opts);
-
-    opts.modules = opts.modules.map(function(mod) {
-      if(moduleCache[mod]) {
-        return moduleCache[mod];
-      }
-      moduleCache[mod] = sweet.loadNodeModule(process.cwd(), mod);
-      return moduleCache[mod];
-    });
-
-    opts.readtables.forEach(function(mod) {
-      sweet.setReadtable(mod);
-    });
 
     try {
       var res = sweet.compile(file.contents.toString('utf8'), opts);


### PR DESCRIPTION
When the glob in `gulp.src()` matches multiple files the following happens:

```
$ gulp es6
[19:51:44] Using gulpfile ~/public_html/OpenSource/Test/gulpfile.js
[19:51:44] Starting 'es6'...

/usr/lib/node_modules/sweet.js/node_modules/resolve/lib/sync.js:21
    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?\\)/)) {
          ^
TypeError: Object #<Object> has no method 'match'
    at module.exports (/usr/lib/node_modules/sweet.js/node_modules/resolve/lib/sync.js:21:11)
    at Object.loadNodeModule (/usr/lib/node_modules/sweet.js/lib/sweet.js:186:24)
    at /home/peter/public_html/OpenSource/Test/node_modules/gulp-sweetjs/index.js:33:32
    at Array.map (native)
    at Stream.<anonymous> (/home/peter/public_html/OpenSource/Test/node_modules/gulp-sweetjs/index.js:29:33)
    at Stream.stream.write (/home/peter/public_html/OpenSource/Test/node_modules/gulp-sweetjs/node_modules/event-stream/node_modules/through/index.js:26:11)
    at write (/home/peter/public_html/OpenSource/Test/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:605:24)
    at flow (/home/peter/public_html/OpenSource/Test/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:614:7)
    at Transform.pipeOnReadable (/home/peter/public_html/OpenSource/Test/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:646:5)
    at Transform.emit (events.js:92:17)
```

As far as I can tell this happens because the module cache doesn't work as intended. `opts.modules` starts out as an array of strings which gets turned into an array of loaded modules when the first file is processed. When the second file is processed, the array is iterated over again and `sweet.loadNodeModule()` gets passed an object (the loaded module) instead of a path.

Is there a reason why the modules and readtables are re-setup for each file? If not, here's the fix that works for me.
