### PR TITLE
Add 'gulpplugin' keyword.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/jlongster/gulp-sweetjs.git"
   },
+  "keywords": ["gulpplugin"]
   "dependencies": {
     "event-stream": "^3.1.5",
     "gulp-util": "^2.2.19",


### PR DESCRIPTION
With this keyword, your package will show up on http://gulpjs.com/plugins/.

Have to reupload a new version to npm though, and by PR convention, I'm not automatically bumping up the version number.
