### PR TITLE
Fix Issue #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ module.exports = function(opts) {
       );
     }
 
-    opts = merge({
+    opts = merge(opts, {
       sourceMap: !!file.sourceMap,
       filename: file.path,
-    }, opts);
+    });
 
     var dest = gutil.replaceExtension(file.path, '.js');
     try {


### PR DESCRIPTION
merge(o1, o2) will add the properties of o2 to o1 if they don't already exist. Since opts gets reused during each pass, this effectively caches the first file's values.
