### PR TITLE
Setting file contents before calling applySourceMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,13 +50,16 @@ module.exports = function(opts) {
       return this.emit('error', err);
     }
 
+    file.contents = new Buffer(res.code);
+
     if(res.sourceMap) {
       var sm = JSON.parse(res.sourceMap);
-      sm.file = file.path;
+      sm.sources = [file.relative];
+      sm.sourcesContent = [String(file.contents)];
+      sm.file = file.relative;
       applySourceMap(file, sm);
     }
 
-    file.contents = new Buffer(res.code);
     file.path = dest;
     this.emit('data', file);
   });

--- a/index.js
+++ b/index.js
@@ -50,12 +50,13 @@ module.exports = function(opts) {
       return this.emit('error', err);
     }
 
+    var originalContents = String(file.contents);
     file.contents = new Buffer(res.code);
 
     if(res.sourceMap) {
       var sm = JSON.parse(res.sourceMap);
       sm.sources = [file.relative];
-      sm.sourcesContent = [String(file.contents)];
+      sm.sourcesContent = [originalContents];
       sm.file = file.relative;
       applySourceMap(file, sm);
     }


### PR DESCRIPTION
applySourceMap needs to have the new content (of an intermediate source modification step) set before being called. Without it, the line numbers in subsequent apply steps wont be calculated correctly. The pattern used is basically what vinyl-sourcemaps-apply package suggests.
